### PR TITLE
gem rack cors, install axios, add mock data to adventures controller

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8080",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "axios": "8.19.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/components/AdventuresList.jsx
+++ b/client/src/components/AdventuresList.jsx
@@ -1,9 +1,26 @@
-import React from 'react';
-import adventures from '../mocks/adventures'; 
+import React, { useEffect, useState } from 'react';
+// import adventures from '../mocks/adventures'; 
+
+import axios from 'axios';
+
 import '../styles/AdventuresList.scss'
 import AdventureListItem from './AdventureListItem';
 
 function AdventuresList() {
+  const [adventures, setAdventures] = useState([]);
+
+  useEffect(() => {
+    console.log('Sending Axios request to /adventures');
+    axios.get('/adventures')
+      .then(response => {
+        console.log('Adventure Data:', response.data)
+        setAdventures(response.data);
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }, []);
+
   return (
     <div className="adventures-list">
       {adventures.map((adventure) => (

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -34,7 +34,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.7.2)
@@ -172,6 +174,7 @@ DEPENDENCIES
   debug
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.7, >= 7.0.7.2)
   tzinfo-data
 

--- a/server/app/controllers/adventures_controller.rb
+++ b/server/app/controllers/adventures_controller.rb
@@ -1,0 +1,35 @@
+class AdventuresController < ApplicationController
+  def index 
+    # adventures = Adventure.all
+    
+    adventures = [
+      {
+        id: 1,
+        latitude: 49.2827,
+        longitude: -123.1207,
+        imageUrl: 'https://th.bing.com/th/id/OIP.GDW4NiEmbTNvLa9eQoCGCQHaE6?pid=ImgDet&rs=1', 
+        description: 'Explore the stunning landscapes of Vancouver on this scenic hike.',
+        difficulty: 'Moderate',
+      },
+      {
+        id: 2,
+        latitude: 49.2827,
+        longitude: -123.1250,
+        imageUrl: 'https://www.insidevancouver.ca/wp-content/uploads/2019/09/07012_201709_DevinManky_Grouse-MountainBikeMountain-BikingSummer-664x443.jpg', 
+        description: 'Experience adrenaline-pumping mountain biking trails near Vancouver.',
+        difficulty: 'Challenging',
+      },
+      {
+        id: 3,
+        latitude: 49.2827,
+        longitude: -123.1150,
+        imageUrl: 'https://th.bing.com/th/id/R.8c19d0b9e798499bb05b2ba72c9a1a47?rik=CswC3v%2fvu238tw&riu=http%3a%2f%2fwww.realadventures.com%2flistingimages%2f1021%2f1021299%2fl_1021299h.jpg&ehk=8q9TPGbM8DEEzMrWUCK8Tu%2bW%2f2LaSq6t9qZZLGTFGz4%3d&risl=&pid=ImgRaw&r=0', 
+        description: 'Kayak through the pristine waters of Vancouver Island.',
+        difficulty: 'Easy',
+      },
+    ];
+
+
+    render json: adventures
+  end
+end

--- a/server/config/initializers/cors.rb
+++ b/server/config/initializers/cors.rb
@@ -5,12 +5,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "http://localhost:3000"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      # credentials: true # => if we need to support cookies or authentication
+  end
+end

--- a/server/config/initializers/cors.rb
+++ b/server/config/initializers/cors.rb
@@ -11,7 +11,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head],
-      # credentials: true # => if we need to support cookies or authentication
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      # credentials: true # if we need to support cookies or authentication
   end
 end
+

--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 8080 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
-  get 'home/index'
-  get 'users/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  root "home#index"
+  # root "home#index"
 
+  resources :adventures
+  resources :locations
+  resources :user_adventures
 
-  resources :users, only: [:index]
 end

--- a/server/test/controllers/adventures_controller_test.rb
+++ b/server/test/controllers/adventures_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AdventuresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Puma.rb file changed as follows to avoid port conflicts:
< Port ENV.fetch(“PORT”) { 8080 } >

“Proxy:  http://localhost:8080/” added to package.json so axios requests know where to look

Gem “rack-cors” uncommented out in Gemfile and bundle reinstalled to activate cross origin resource sharing 

AdventureList component modified for useEffect implementation and axios import/ fetch request

Ahmad’s mock data copied over to adventures_controller.rb to see the axios fetch was successful

so you'll need to bundle install and also npm install axios